### PR TITLE
"drawing.finish()" -> "recognizer.finish()" and add drawing.clear()

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -214,9 +214,12 @@ drawing.removeStroke(stroke)
 // Get a new prediction.
 await drawing.getPrediction()
 
-// Complete the drawing and free up resources. Subsequent calls on the drawing
-// object will throw an error.
-await drawing.finish()
+// Clear all the strokes.
+drawing.clear()
+
+// Complete the recognition and free up resources. Subsequent calls on the 
+// corresponding drawing object will throw an error.
+await recognizer.finish()
 ```
 
 


### PR DESCRIPTION
This is because the underlying resource should be represented by
recognizer rather than drawing.