### PR TITLE
Add `graphemeSet` to Web IDL

### DIFF
--- a/idl.md
+++ b/idl.md
@@ -42,6 +42,7 @@ interface HandwritingRecognizer {
 };
 
 dictionary HandwritingHints {
+  sequence<DOMString> graphemeSet = [];
   DOMString recognitionType = "text";
   DOMString inputType = "mouse";
   DOMString textContext = "";


### PR DESCRIPTION
`graphemeSet` is [mentioned in the explainer](https://github.com/WICG/handwriting-recognition/blob/main/explainer.md#recognition-hints) as a property of handwriting hints, but does not appear in the Web IDL.