### PR TITLE
explainer: use DOMHighResTimestamp instead of DOMTimestamp

### DIFF
--- a/idl.md
+++ b/idl.md
@@ -64,8 +64,8 @@ dictionary HandwritingPoint {
   double x;
   double y;
 
-  // Timestamp in milliseconds since the start of the current drawing.
-  DOMTimeStamp t;
+  // The amount of time since the start of the current drawing.
+  DOMHighResTimestamp t;
 };
 ```
 


### PR DESCRIPTION
Per discussions in https://github.com/heycam/webidl/issues/2.