### PR TITLE
Remove non-standards RaisesException extended attribute

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -338,10 +338,9 @@ This method creates a {{HandwritingRecognizer}} object that satisfies the provid
 <xmp class="idl">
 [Exposed=Window, SecureContext]
 interface HandwritingRecognizer {
-  [RaisesException]
   HandwritingDrawing startDrawing(optional HandwritingHints hints = {});
 
-  [RaisesException] undefined finish();
+  undefined finish();
 };
 
 dictionary HandwritingHints {


### PR DESCRIPTION
See https://github.com/whatwg/webidl/issues/603 for discussion on standardizing a similar extended attribute in WebIDL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/handwriting-recognition/pull/31.html" title="Last updated on Jun 26, 2024, 8:51 AM UTC (20c51a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/handwriting-recognition/31/498e365...dontcallmedom:20c51a2.html" title="Last updated on Jun 26, 2024, 8:51 AM UTC (20c51a2)">Diff</a>