### PR TITLE
Update QuotaExceededError usage

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -328,12 +328,12 @@ This method creates a {{HandwritingRecognizer}} object that satisfies the provid
   1. Run the following steps [=in parallel=]:
     1. <a lt="convert">Convert |constraint| into a suitable form</a> for creating a platform-dependent [=handwriting recognizer=].
     1. [=Queue a Handwriting Recognition API task=] to:
-      1. If the user agent can't create or prepare a [=handwriting recognizer=] to perform recognitions, [=/reject=] |p| with a new {{DOMException}} according to the failure cause:
-        * If |constraint|'s {{HandwritingModelConstraint/languages}} is an empty [=list=], {{"NotSupportedError"}}.
-        * If the user agent can't find a platform-dependent [=handwriting recognizer=] that satisfies the converted |constraint|, {{"NotSupportedError"}}.
-        * If creating a [=handwriting recognizer=] would cause the user agent to exceed its limit for total number of active recognizer, {{"QuotaExceededError"}}.
-        * If the web application can retry calling this method, {{OperationError}}.
-        * For all other failure causes, {{"UnknownError"}}
+      1. If the user agent can't create or prepare a [=handwriting recognizer=] to perform recognitions, [=/reject=] |p| with a new exception according to the failure cause:
+        * If |constraint|'s {{HandwritingModelConstraint/languages}} is an empty [=list=], {{"NotSupportedError"}} {{DOMException}}.
+        * If the user agent can't find a platform-dependent [=handwriting recognizer=] that satisfies the converted |constraint|, {{"NotSupportedError"}} {{DOMException}}.
+        * If creating a [=handwriting recognizer=] would cause the user agent to exceed its limit for total number of active recognizer, {{QuotaExceededError}}.
+        * If the web application can retry calling this method, {{"OperationError"}}  {{DOMException}}.
+        * For all other failure causes, {{"UnknownError"}} {{DOMException}}.
       1. Otherwise:
         1. Let |result| be a new {{HandwritingRecognizer}} object.
         1. Associate |result| with the platform-dependent [=handwriting recognizer=] created in the previous step.
@@ -658,7 +658,7 @@ If the handwriting recognizer wasn't able to recognize anything, {{HandwritingDr
 <div algorithm="handwriting-drawing-get-prediction">
   When {{HandwritingDrawing/getPrediction()}} is invoked:
 
-  1. If `this`.[=HandwritingDrawing/recognizer=].[=HandwritingRecognizer/active=] isn't true, return a [=a promise rejected with=] {{"InvalidStateError"}} {{DOMException}}. 
+  1. If `this`.[=HandwritingDrawing/recognizer=].[=HandwritingRecognizer/active=] isn't true, return a [=a promise rejected with=] {{"InvalidStateError"}} {{DOMException}}.
   1. If `this`.[=HandwritingDrawing/strokes=] is empty, return a [=a promise resolved with=] a new empty [=list=].
   1. <a lt="convert">Convert `this` drawing into a format suitable</a> for [=handwriting recognizer=].
   1. Let |p| be a new Promise, run the following step [=in parallel=]


### PR DESCRIPTION
QuotaExceededError is graduating from being a DOMException name into a new error class, in https://github.com/whatwg/webidl/pull/1465. Update creation sites to reflect this.

For now, the quota and requested properties are left at their default (null). Future work could include setting them in an informative fashion.